### PR TITLE
複数画像投稿、修正

### DIFF
--- a/app/assets/javascripts/new_item.js
+++ b/app/assets/javascripts/new_item.js
@@ -4,13 +4,14 @@ $(function(){
   var file_field = document.querySelector('input[type=file]')
 
   $('.hidden-field').change(function(){
+    var index = $(this).data("image")
+    console.log(this)
+    console.log(index)
     var file = $('input[type="file"]').prop('files')[0];
     $.each(this.files, function(i, file){
       var fileReader = new FileReader();
 
       dataBox.items.add(file)
-
-      file_field.files = dataBox.files
 
       var num = $('.item-image').length + 1 + i
       fileReader.readAsDataURL(file);
@@ -35,6 +36,7 @@ $(function(){
       };
       $('#image-block__boxes').attr('class', `item-num-${num}`)
     });
+    $(".image-label").prop("for", `item_images_attributes_${index + 1}_url`)
   });
   $(document).on("click", '.item-image__operation__delete', function(){
   var target_image = $(this).parent().parent()

--- a/app/assets/javascripts/new_item.js
+++ b/app/assets/javascripts/new_item.js
@@ -5,8 +5,6 @@ $(function(){
 
   $('.hidden-field').change(function(){
     var index = $(this).data("image")
-    console.log(this)
-    console.log(index)
     var file = $('input[type="file"]').prop('files')[0];
     $.each(this.files, function(i, file){
       var fileReader = new FileReader();

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:edit, :show, :update, :destroy]
-
+  before_action :set_category, only: [:new, :create, :edit, :update]
   require 'payjp'
 
 
@@ -52,11 +52,9 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
-    5.times do 
+    5.times do
       @item.images.build
     end
-
-    @category_parent_array = Category.where(ancestry: nil).inject([]) { |category_parent_array,(name)| category_parent_array << name}
   end
 
   def get_category_children
@@ -114,6 +112,10 @@ class ItemsController < ApplicationController
   private
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def set_category
+    @category_parent_array = Category.where(ancestry: nil).inject([]) { |category_parent_array,(name)| category_parent_array << name}
   end
 
   def item_params

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -11,11 +11,11 @@
         %p 最大5枚までアップロードできます
         .float-box
           .item-num-0#image-block__boxes
-            %label
+            %label.image-label{for: "item_images_attributes_0_url"}
               .image-block__boxes__image-box
                 %i.fas.fa-camera
               = f.fields_for :images do |image|
-                = image.file_field :url, type: 'file', class: 'hidden-field'
+                = image.file_field :url, type: 'file', class: "hidden-field", data: {image: image.index}
     
       .item-info
         .item-info__name-block


### PR DESCRIPTION
#what
複数画像投稿ができていなかったため、できるように修正した。
厳密に言えば、画像データがどんどん上書きされてしまっていて、一番最後に入れた画像のみデータベースに保存されていた。
修正を行う際、カテゴリーに関するエラーが出たため、そこも少し修正した。

#why
原因は二つ。
まずviewファイル中の画像投稿に関するlabelの名前が画像選択の際に変わっておらず、毎回同じ場所に画像のurlが保存されていた。

もう一つの原因が、jsファイルの記述に、同じinputファイルに複数枚保存される仕様になっていたため、viewファイルとの齟齬が生まれた、というものである。

行った作業としては、
①viewファイル中の画像投稿に関するlabelに名前をつけた。
②jsファイルで画像が選択されるたびにlabelの名前が変わるように実装。
③最後にjsファイルにあった同じinputファイルに複数枚保存される仕様を削除した。