### PR TITLE
商品出品のエラーハンドリング

### DIFF
--- a/app/assets/javascripts/new_item.js
+++ b/app/assets/javascripts/new_item.js
@@ -42,7 +42,6 @@ $(function(){
   if(file_field.files.length==1){
     $('input[type=file]').val(null)
     dataBox.clearData();
-    // console.log(dataBox)
   }else{
     $.each(file_field.files, function(i,input){
       if(input.name==target_name){
@@ -79,14 +78,14 @@ $(function(){
 //カテゴリー選択
 $(function(){
   function appendOption(category){
-    var html = `<option value="${category.name}" data-category="${category.id}">${category.name}</option>`;
+    var html = `<option value="${category.id}" data-category="${category.id}">${category.name}</option>`;
     return html;
   }
   function appendChidrenBox(insertHTML){
     var childSelectHtml = '';
     childSelectHtml = `<div class='listing-select-wrapper__added' id= 'children_wrapper'>
                         <div class='listing-select-wrapper__box'>
-                          <select class="listing-select-wrapper__box--select" id="child_category" name="category_id">
+                          <select class="listing-select-wrapper__box--select" id="child_category" name="item[category_id]">
                             <option value="選択してください" data-category="選択してください">選択してください</option>
                             ${insertHTML}
                           <select>
@@ -98,7 +97,7 @@ $(function(){
     var grandchildSelectHtml = '';
     grandchildSelectHtml = `<div class='listing-select-wrapper__added' id= 'grandchildren_wrapper'>
                               <div class='listing-select-wrapper__box'>
-                                <select class="listing-select-wrapper__box--select" id="grandchild_category" name="category_id">
+                                <select class="listing-select-wrapper__box--select" id="grandchild_category" name="item[category_id]">
                                   <option value="選択してください" data-category="選択してください">選択してください</option>
                                   ${insertHTML}
                                 </select>
@@ -109,9 +108,9 @@ $(function(){
   // 親カテゴリー選択後のイベント
   $('#parent_category').on('change', function(){
     var parentCategory = document.getElementById('parent_category').value;
-    if (parentCategory != "選択してください"){
+    if (parentCategory != ""){
       $.ajax({
-        url: 'get_category_children',
+        url: '/items/get_category_children',
         type: 'GET',
         data: { parent_name: parentCategory },
         dataType: 'json'
@@ -138,7 +137,7 @@ $(function(){
     var childId = $('#child_category option:selected').data('category');
     if (childId != "選択してください"){ 
       $.ajax({
-        url: 'get_category_grandchildren',
+        url: '/items/get_category_grandchildren',
         type: 'GET',
         data: { child_id: childId },
         dataType: 'json'

--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -23,7 +23,7 @@
         padding: 10px;
         margin-bottom: 20px;
         font-size: 20px;
-        #error_explanation {
+        ul {
           background-color: #f5f5f5;
           color: #160606;
           padding: 10px 10px 20px;

--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -16,6 +16,20 @@
       width: 650px;
       margin: 0 auto;
       padding: 20px 50px 200px;
+      .error{
+        background-color: red;
+        width: 100%;
+        color: white;
+        padding: 10px;
+        margin-bottom: 20px;
+        font-size: 20px;
+        #error_explanation {
+          background-color: #f5f5f5;
+          color: #160606;
+          padding: 10px 10px 20px;
+          font-size: 16px;
+        }
+      }
       .head {
         font-size: 25px;
         text-align: center;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -57,21 +57,19 @@ class ItemsController < ApplicationController
     end
   end
 
-  def get_category_children
-    @category_children = Category.where(ancestry: "#{params[:parent_name]}")
-  end
-
-  def get_category_grandchildren
-    @category_grandchildren = Category.find("#{params[:child_id]}").children
-  end
-
   def create
     @item = Item.new(item_params)
     if @item.save
       redirect_to item_path(@item), notice: '商品が出品されました'
     else
+      num = @item.images.length
+      (5 - num).times do
+        @item.images.build
+      end
+      @grand_children_categories = @item.category.siblings if @item.category.present?
+      @children_categories = @item.category.parent.siblings if @item.category.present?
       flash.now[:alert] = '必須項目が抜けています'
-      render new_item_path
+      render :new
     end
   end
 
@@ -109,13 +107,21 @@ class ItemsController < ApplicationController
     end
   end
 
+  def set_category
+    @category_parent_array = Category.where(ancestry: nil).inject([]) { |category_parent_array,(name)| category_parent_array << name}
+  end
+
+  def get_category_children
+    @category_children = Category.where(ancestry: "#{params[:parent_name]}")
+  end
+
+  def get_category_grandchildren
+    @category_grandchildren = Category.find("#{params[:child_id]}").children
+  end
+
   private
   def set_item
     @item = Item.find(params[:id])
-  end
-
-  def set_category
-    @category_parent_array = Category.where(ancestry: nil).inject([]) { |category_parent_array,(name)| category_parent_array << name}
   end
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,11 +5,12 @@ class Item < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true
-  belongs_to :category
+  belongs_to :category, optional: true
   accepts_nested_attributes_for :category
   belongs_to :saler, class_name: "User", optional: true,foreign_key: "saler_id"
   belongs_to :buyer, class_name: "User", optional: true,foreign_key: "buyer_id"
 
+  validates :images, {presence: true}
   validates :name, {presence: true}
   validates :price, {presence: true}
   validates :text, {presence: true}

--- a/app/views/items/_error_messages.html.haml
+++ b/app/views/items/_error_messages.html.haml
@@ -1,0 +1,10 @@
+- if resource.errors.any?
+  #error_explanation
+    %p 以下の項目を入力してください
+    -# %h2
+    -#   = I18n.t("errors.messages.not_saved",                 |
+    -#     count: resource.errors.count,                       |
+    -#     resource: resource.class.model_name.human.downcase) |
+    %ul
+      - resource.errors.full_messages.each do |message|
+        %li= message

--- a/app/views/items/_error_messages.html.haml
+++ b/app/views/items/_error_messages.html.haml
@@ -1,10 +1,11 @@
 - if resource.errors.any?
-  #error_explanation
-    %p 以下の項目を入力してください
+  #error_explanation 
     -# %h2
     -#   = I18n.t("errors.messages.not_saved",                 |
     -#     count: resource.errors.count,                       |
     -#     resource: resource.class.model_name.human.downcase) |
-    %ul
-      - resource.errors.full_messages.each do |message|
-        %li= message
+    .error
+      %p 以下の項目を入力してください
+      %ul
+        - resource.errors.full_messages.each do |message|
+          %li= message

--- a/app/views/items/_error_messages.html.haml
+++ b/app/views/items/_error_messages.html.haml
@@ -1,9 +1,5 @@
 - if resource.errors.any?
   #error_explanation 
-    -# %h2
-    -#   = I18n.t("errors.messages.not_saved",                 |
-    -#     count: resource.errors.count,                       |
-    -#     resource: resource.class.model_name.human.downcase) |
     .error
       %p 以下の項目を入力してください
       %ul

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,6 +1,7 @@
 .main
   .main__block
     = form_for @item do |f|
+      = render "items/error_messages", resource: f.object
       %h2.head
         商品情報入力
       .image-block
@@ -40,7 +41,11 @@
               カテゴリー
             %b#require 必須
           .item-detail__categories
-            = f.collection_select :category_id, @category_parent_array, :id, :name, {prompt: "選択してください"}, {id: 'parent_category', class: 'item-detail__categories__category-box'}
+            = f.collection_select :category_id, @category_parent_array, :id, :name, {prompt: "選択してください"}, {id: 'parent_category'}
+            - if @children_categories.present?
+              = f.collection_select :category_id, @children_categories, :id, :name, {selected: @item.category.parent_id},{id: 'children_wrapper'}
+            - if @grand_children_categories.present?
+              = f.collection_select :category_id, @grand_children_categories, :id, :name, {selected: @item.category_id}, {id: 'grandchildren_wrapper'}
 
 
           .item-detail__brand


### PR DESCRIPTION
#what
商品出品時に必須項目が抜けていた際のエラーを実装した。
行ったこと。
①エラー文が表示されるように、itemsのビューにerror.html.hamlを作成
②画像が何も選択されなかった際に、ファイルが消えるエラーが起きたため、render時に[５ − 入っている画像の枚数]のファイルをbuildしたことで解消した。
③カテゴリーが孫まで選択された状態でバリデーションエラーが起こると、render で newに帰ってきた際に、親カテゴリーのみ残っているエラーが起きた。こちらに関しては、コントローラーに子・孫カテゴリーの情報を持たせ、ビューにて、ない場合とある場合で条件分岐させることで解消した。

最後に、「categoryを入力してください」というエラーメッセージが二回表示されたため、itemモデルのcategoryの部分に optional: true を追加することで解消した。

#why
why...? この場合whyってなんだ...
えー、エラーハンドリングがないと、出品者がどこをミスっているのか分からないため。

#未完成のところ
・英語→日本語に修正
・項目別にエラー表示（名前の下か上に「名前を入力してください」）