### PR TITLE
商品出品エラーハンドリング3

### DIFF
--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -5,6 +5,17 @@
   $block-solid:solid 1px rgb(196, 207, 207);
   $block-padding-bottom: 20px;
   $block-margin-top: 50px;
+
+  .error_message{
+    font-size: 15px;
+    color: red;
+    margin-top: 5px;
+  }
+
+  .field_with_errors {
+    outline: 0;
+    border-color: #3CCACE;
+  }
   
   .main {
     height: 100vh;

--- a/app/helpers/with_items_error_form_builder.rb
+++ b/app/helpers/with_items_error_form_builder.rb
@@ -1,0 +1,46 @@
+class WithItemsErrorFormBuilder < ActionView::Helpers::FormBuilder
+
+  def pick_errors(attribute)
+    return nil if @object.nil? || (messages = @object.errors.messages[attribute]).nil?
+
+    lis = messages.collect do |message|
+      %{<li>#{@object.errors.full_message(attribute, message)}</li>}
+    end.join
+
+    %{<ul class="error_message">#{lis}</ul>}.html_safe
+  end
+
+  def text_field(attribute, options={})
+    return super if options[:no_errors]
+    super + pick_errors(attribute)
+  end
+
+  def file_field(attribute, options={})
+    return super if options[:no_errors]
+    super + pick_errors(attribute)
+  end
+
+  def text_area(attribute, options={})
+    return super if options[:no_errors]
+    super + pick_errors(attribute)
+  end
+
+  def number_field(attribute, options={})
+    return super if options[:no_errors]
+    super + pick_errors(attribute)
+  end
+
+  def collection_select(method, collection, value_method, text_method, options = {}, html_options = {})
+    return super if options[:no_errors]
+    super + pick_errors(method)
+  end
+
+  (field_helpers - [:label, :radio_button, :hidden_field]).each do |selector|
+    class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
+      def #{selector}(attribute, options = {})
+        return super if options[:no_errors]
+        super + pick_errors(attribute)
+      end
+    RUBY_EVAL
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,16 +10,15 @@ class Item < ApplicationRecord
   belongs_to :saler, class_name: "User", optional: true,foreign_key: "saler_id"
   belongs_to :buyer, class_name: "User", optional: true,foreign_key: "buyer_id"
 
-  validates :images, {presence: true}
-  validates :name, {presence: true}
-  validates :price, {presence: true}
-  validates :text, {presence: true}
-  validates :category_id, {presence: true}
+  validates :images, presence: {message: 'を投稿してください'}
+  validates :name, presence: {message: 'を入力してください'}
+  validates :text, presence: {message: 'について何か語ってくださいな'}
+  validates :category_id, presence: {message: 'を選択してください'}
   validates :condition, {presence: true}
-  validates :shipping_charge, {presence: true}
   validates :shipping_origin, {presence: true}
+  validates :shipping_charge, {presence: true}
   validates :shipping_schedule, {presence: true}
-
+  validates :price, presence: {message: 'を設定しない？嘘でしょ'}
 end
 
 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,6 +1,6 @@
 .main
   .main__block
-    = form_for @item do |f|
+    = form_for @item, builder: WithItemsErrorFormBuilder do |f|
       = render "items/error_messages", resource: f.object
       %h2.head
         商品情報入力
@@ -18,6 +18,8 @@
               = f.fields_for :images do |image|
                 = image.file_field :url, type: 'file', class: "hidden-field", data: {image: image.index}
     
+      
+      
       .item-info
         .item-info__name-block
           .item-info__name-block__form
@@ -33,6 +35,8 @@
             %b#require 必須
           = f.text_area :text, class: 'item-info__descript__descript-box', rows: '7', placeholder:"商品の説明（1000文字以内）"
 
+
+
       .item-detail
         %p 商品の詳細
         .item-detail__category
@@ -47,7 +51,6 @@
             - if @grand_children_categories.present?
               = f.collection_select :category_id, @grand_children_categories, :id, :name, {selected: @item.category_id}, {id: 'grandchildren_wrapper'}
 
-
           .item-detail__brand
             .item-detail__brand__form
               %b.item-head
@@ -55,13 +58,13 @@
               %b#require 任意
             = f.text_area :brand_id, class: "brand-input"
 
-
           .item-detail__status
             .item-detail__status__form
               %b.item-head
                 商品の状態
               %b#require 必須
             = f.select :condition, [["新品、未使用", 1], ["未使用に近い", 2], ["目立った傷や汚れなし", 3], ["やや傷や汚れあり", 4], ["傷や汚れあり", 5], ["全体的に状態が悪い", 6]]
+
 
         .item-send
           %p 配送について

--- a/config/locales/items.ja.yml
+++ b/config/locales/items.ja.yml
@@ -4,7 +4,7 @@ ja:
      item:
       images: 画像
       name: 商品名
-      text: 商品
+      text: 商品の説明
       category_id: カテゴリー
       shipping_origin: 発送元
       shipping_charge: 配送料

--- a/config/locales/items.ja.yml
+++ b/config/locales/items.ja.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    attributes:
+     item:
+      images: 画像
+      name: 商品名
+      text: 商品
+      category_id: カテゴリー
+      shipping_origin: 発送元
+      shipping_charge: 配送料
+      price: 価格


### PR DESCRIPTION
#what
商品出品時のエラーメッセージについて追加
①英語でカラムが表記されていたのを作成した items.ja.yml に日本語で対応するように設定した。
②エラー文がそれぞれの項目の下にに出るように、with_items_error_form_builder.rb を作成し、ヘルパーメソッドを定義していった。
③全てのエラーメッセージが「〜を入力してください」と表示されていたため、itemモデルにて message メソッドを使い、「〜を選択してください」などに変更した。

#why
①出品者がどこを入力し忘れているのかわかりやすくするため
②①と同様
③見ていて日本語が合わないのが気持ち悪かったため
