### PR TITLE
価格のバリデーション

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,6 +20,11 @@ class Item < ApplicationRecord
   validates :shipping_charge, {presence: true}
   validates :shipping_schedule, {presence: true}
   validates :price, presence: {message: 'を設定しない？嘘でしょ'}
+  validates :price, numericality: { greater_than_or_equal_to: 300, message: 'は300円以上から設定できます'}, unless: :nil_price
+  validates :price, numericality: { less_than_or_equal_to: 9999999, message: 'は9999999円以下で設定してください'}, unless: :nil_price
+  def nil_price
+    price == nil
+  end
 end
 
 


### PR DESCRIPTION
#what
商品出品時に300~9999999以外の値にバリデーションがかかるようにした。
また空白の時は、上記のバリデーションがかからないように設定した。 (unless文)

#why
値が0でも90000000000でも出品できてしまっていた。
空白の時も上記のバリデーションによるエラー文(〜円以下で設定してください)が出るのがなんか気持ち悪かったため。

#エラーの様子
https://gyazo.com/688553b2050500ea8eeb456eb1d974d3