### PR TITLE
出品時のエラー解消(フロントエンドにて解消)

### DIFF
--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -16,12 +16,22 @@
     outline: 0;
     border-color: #3CCACE;
   }
+
   
-  .main {
+  .item-main {
     height: 100vh;
     width: 100vw;
     background-color: #f8f8f8;
     overflow: scroll;
+    .icon {
+      height: 80px;
+      text-align: center;
+      margin-bottom: 20px;
+      padding-top: 40px;
+      .iconImage {
+        margin: 0 auto;
+      }
+    }
     &__block {
       background-color: #ffffff;
       width: 650px;
@@ -43,7 +53,7 @@
       }
       .head {
         font-size: 25px;
-        text-align: center;
+        // text-align: center;
         margin-bottom: 70px;
         color: #3CCACE;
         border-bottom: solid 1px;

--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -53,7 +53,6 @@
       }
       .head {
         font-size: 25px;
-        // text-align: center;
         margin-bottom: 70px;
         color: #3CCACE;
         border-bottom: solid 1px;

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,7 +1,9 @@
-=render "mainheader"
+.item-main
 
-.main
-  .main__block
+  .icon
+    = image_tag "icon-header.svg", alt: "Furima App", size: "140x40", class: "iconImage"
+
+  .item-main__block
     = form_for @item, builder: WithItemsErrorFormBuilder do |f|
       = render "items/error_messages", resource: f.object
       %h2.head


### PR DESCRIPTION
#what
出品ボタンを押すと undefind method 'each' for nil のエラーが出ていたため、エラーの箇所を探したところ、部分テンプレートであるヘッダーの「カテゴリー探す」の部分と、商品情報入力の際の「カテゴリー選択」の部分で名前が被っていることによりエラーが起きていた。
そのため、商品出品画面のヘッダーは無しにして、代わりに FURIMAのアイコンだけ上に表示した。
https://gyazo.com/bd20d77dc666fca9c37a75c394082d4d

#why
エラーをサーバーサイドで解消するよりも、フロントエンドで解消する方が早く、他の不具合を起こさないようにするのに効率的だったため。